### PR TITLE
Add autonomous balance routine

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -91,11 +91,28 @@ public class RobotContainer {
         m_chooser.addOption("Center: Back Up + Driveout",
                 GoToInches(-14, 0)
                 .andThen(GoToInches(135, 0)));
+        
+        m_chooser.addOption("Center: Balance Only",
+            GoToInches_ExitOnRoll(60.0, 0.0)
+        .andThen(new AutoBalanceCommand(m_drivetrainSubsystem)));
+        
+        m_chooser.addOption("Center: Drive Out then Balance",
+                GoToInches_ExitOnRoll(60.0, 0.0)
+                .andThen(GoToInches(100.0, 0.0))
+                .andThen(GoToInches(200.0, 0.0))
+                .andThen(GoToInches_ExitOnRoll(60.0, 0.0))
+                .andThen(new AutoBalanceCommand(m_drivetrainSubsystem)));
 
         m_chooser.addOption("Center: Back Up + Driveout + Charge",
                 GoToInches(-14, 0)
                 .andThen(GoToInches(135, 0))
                 .andThen(GoToInches(75, 0)));
+
+        m_chooser.addOption("Left: Driveout + Charge",
+                GoToInches(180, 0)
+                .andThen(GoToInches(180, -70))
+                .andThen(GoToInches_ExitOnRoll(100, -70))
+                .andThen(new AutoBalanceCommand(m_drivetrainSubsystem)));
 
         m_chooser.addOption("Left: Back Up + Driveout + Charge",
                 GoToInches(-14, 0)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -55,7 +55,12 @@ public class RobotContainer {
 
     DriveToPoseCommand GoToInches(double x, double y)
     {
-        return new DriveToPoseCommand(m_drivetrainSubsystem, poseEstimator, translate_pose_inches(startingPose, x, y));
+        return new DriveToPoseCommand(m_drivetrainSubsystem, poseEstimator, translate_pose_inches(startingPose, x, y), false);
+    }
+
+    DriveToPoseCommand GoToInches_ExitOnRoll(double x, double y)
+    {
+        return new DriveToPoseCommand(m_drivetrainSubsystem, poseEstimator, translate_pose_inches(startingPose, x, y), true);
     }
 
     /**
@@ -158,7 +163,7 @@ public class RobotContainer {
         // new JoystickButton(m_controller, 11).onTrue(GoToInches(48, 48));
         // new JoystickButton(m_controller, 12).onTrue(GoToInches(24, 48));
 
-        new JoystickButton(m_controller, 2).whileTrue(new AutoBalanceCommand(m_drivetrainSubsystem, () -> poseEstimator.getCurrentPose().getRotation()));
+        new JoystickButton(m_controller, 2).whileTrue(new AutoBalanceCommand(m_drivetrainSubsystem));
         new JoystickButton(m_controller, 5).whileTrue(new AlignToCubeChannelCommand(m_drivetrainSubsystem, poseEstimator));
 
         // controller.rightTrigger().whileTrue(new DriveToPoseCommand(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -158,6 +158,7 @@ public class RobotContainer {
         // new JoystickButton(m_controller, 11).onTrue(GoToInches(48, 48));
         // new JoystickButton(m_controller, 12).onTrue(GoToInches(24, 48));
 
+        new JoystickButton(m_controller, 2).whileTrue(new AutoBalanceCommand(m_drivetrainSubsystem, () -> poseEstimator.getCurrentPose().getRotation()));
         new JoystickButton(m_controller, 5).whileTrue(new AlignToCubeChannelCommand(m_drivetrainSubsystem, poseEstimator));
 
         // controller.rightTrigger().whileTrue(new DriveToPoseCommand(

--- a/src/main/java/frc/robot/commands/AutoBalanceCommand.java
+++ b/src/main/java/frc/robot/commands/AutoBalanceCommand.java
@@ -1,0 +1,72 @@
+package frc.robot.commands;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.DrivetrainSubsystem;
+
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+
+public class AutoBalanceCommand extends CommandBase {
+    private final DrivetrainSubsystem m_drivetrainSubsystem;
+    private double m_onBalanceThreshold = 2.5;
+    private double m_maxVelocity_mps = 0.35;
+
+    public AutoBalanceCommand(DrivetrainSubsystem drivetrainSubsystem,
+        Supplier<Rotation2d> robotAngleSupplier) {
+        this.m_drivetrainSubsystem = drivetrainSubsystem;
+
+        addRequirements(drivetrainSubsystem);
+    }
+
+    @Override
+    public void initialize() {
+        m_onBalanceThreshold = SmartDashboard.getNumber("autoBalance.onBalanceThreshold", 1.5);
+        m_maxVelocity_mps = SmartDashboard.getNumber("autoBalance.maxVelocity", 0.35);
+    }
+
+    @Override
+    public void execute() {
+        // You can use `new ChassisSpeeds(...)` for robot-oriented movement instead of
+        // field-oriented movement
+
+        double x_meters_per_second = 0.0;
+        double RollAngleDegrees = m_drivetrainSubsystem.getRoll();
+        Boolean balanceRoll = Math.abs(RollAngleDegrees) >= m_onBalanceThreshold;
+        
+        // Control drive system automatically, 
+        // driving in reverse direction of Roll/roll angle,
+        // with a magnitude based upon the angle
+
+        if ( balanceRoll ) {
+            double sign = RollAngleDegrees > 0.0 ? 1.0 : -1.0;
+
+            // 1m/s when we're at a 15 degree angle
+            double min_velocity = 0.02;
+            double max_velocity = 0.6;
+            double P = max_velocity / 15;
+
+            double amplitude = P * RollAngleDegrees;
+
+            amplitude = Math.min(max_velocity, Math.abs(amplitude));
+            amplitude = Math.max(min_velocity, Math.abs(amplitude));
+
+            x_meters_per_second = amplitude * sign;
+        }
+
+        SmartDashboard.putNumber("autoBalance.Roll", RollAngleDegrees);
+        SmartDashboard.putNumber("autoBalance.x_velocity", x_meters_per_second);
+
+        m_drivetrainSubsystem.drive(ChassisSpeeds.fromFieldRelativeSpeeds(
+            x_meters_per_second, 0.0,
+            0.0, m_drivetrainSubsystem.getGyroscopeRotation()));
+    }
+
+    @Override
+    public void end(boolean interrupted) {
+        m_drivetrainSubsystem.drive(new ChassisSpeeds(0.0, 0.0, 0.0));
+    }
+}

--- a/src/main/java/frc/robot/commands/AutoBalanceCommand.java
+++ b/src/main/java/frc/robot/commands/AutoBalanceCommand.java
@@ -12,11 +12,10 @@ import java.util.function.Supplier;
 
 public class AutoBalanceCommand extends CommandBase {
     private final DrivetrainSubsystem m_drivetrainSubsystem;
-    private double m_onBalanceThreshold = 2.5;
+    private double m_onBalanceThreshold = 1.5;
     private double m_maxVelocity_mps = 0.35;
 
-    public AutoBalanceCommand(DrivetrainSubsystem drivetrainSubsystem,
-        Supplier<Rotation2d> robotAngleSupplier) {
+    public AutoBalanceCommand(DrivetrainSubsystem drivetrainSubsystem) {
         this.m_drivetrainSubsystem = drivetrainSubsystem;
 
         addRequirements(drivetrainSubsystem);
@@ -45,8 +44,8 @@ public class AutoBalanceCommand extends CommandBase {
             double sign = RollAngleDegrees > 0.0 ? 1.0 : -1.0;
 
             // 1m/s when we're at a 15 degree angle
-            double min_velocity = 0.02;
-            double max_velocity = 0.6;
+            double min_velocity = 0.017;
+            double max_velocity = 0.5;
             double P = max_velocity / 15;
 
             double amplitude = P * RollAngleDegrees;

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -196,6 +196,15 @@ public class DrivetrainSubsystem extends SubsystemBase {
         // counter-clockwise makes the angle increase.
         return Rotation2d.fromDegrees(360.0 - m_navx.getYaw());
     }
+
+    public float getPitch() {
+        return m_navx.getPitch();
+    }
+
+    public float getRoll() {
+        return m_navx.getRoll();
+    }
+
     public SwerveModulePosition[] getModulePositions() {
         return Arrays.stream(swerveModules).map(module -> module.getPosition()).toArray(SwerveModulePosition[]::new);
     }


### PR DESCRIPTION
This is a rudimentary auto-balance routine.

Assumptions and Caveats:

Auto-balance will always be used with the robot in the starting orientation, facing away from the driver station.
The robot will not fly off the end of the charge station before it drops, causing catastrophic damage. It could be safer to drive around the ends.
Simple algorithm will work well enough. It would benefit from being transformed into a PID mechanism.