### PR TITLE
Add servo-based cube flipper as a contingency option

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -21,6 +21,13 @@ import org.photonvision.PhotonCamera;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
+
+    // Servo assignments
+    public static final int CUBE_FLIPPER_SERVO_CHANNEL = 3;
+    public static final double CUBE_FLIPPER_SERVO_PARK_POS = 0.0;
+    public static final double CUBE_FLIPPER_SERVO_EJECT_POS = 1.0;
+    public static final double CUBE_FLIPPER_EJECT_DELAY_S = 2.0;
+
     /**
      * The left-to-right distance between the drivetrain wheels
      *

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.CommandBase;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
@@ -40,6 +41,14 @@ public class RobotContainer {
 
     private final Joystick m_controller = new Joystick(0);
     private final PoseEstimatorSubsystem poseEstimator = new PoseEstimatorSubsystem(m_drivetrainSubsystem);
+
+    private final CubeFlipperSubsystem m_cubeFlipperSubsystem = new CubeFlipperSubsystem();
+    private CommandBase EjectCubeCommand = Commands.runOnce(m_cubeFlipperSubsystem::eject, m_cubeFlipperSubsystem);
+    private CommandBase ParkCubeFlipperCommand = Commands.runOnce(m_cubeFlipperSubsystem::park, m_cubeFlipperSubsystem);
+    private CommandBase EjectCubeSequence =
+        EjectCubeCommand
+        .andThen(Commands.waitSeconds(Constants.CUBE_FLIPPER_EJECT_DELAY_S))
+        .andThen(ParkCubeFlipperCommand);
 
     private final SendableChooser<Command> m_chooser = new SendableChooser<>();
 
@@ -86,33 +95,41 @@ public class RobotContainer {
         startingPose = poseEstimator.getCurrentPose();
 
         m_chooser.setDefaultOption("None", new InstantCommand());
+
+        m_chooser.addOption("Eject Cube", EjectCubeSequence);
         
-        m_chooser.addOption("Center: Charge Only",
-                GoToInches_ExitOnRoll(center_DriveToRamp_inches, 0.0)
+        m_chooser.addOption("Center: Charge",
+                EjectCubeSequence
+                .andThen(GoToInches_ExitOnRoll(center_DriveToRamp_inches, 0.0))
                 .andThen(new AutoBalanceCommand(m_drivetrainSubsystem)));
         
-        m_chooser.addOption("Center: Drive Out then Charge",
-                GoToInches_ExitOnRoll(center_DriveToRamp_inches, 0.0)
+        m_chooser.addOption("Center: Drive Out + Charge",
+                EjectCubeSequence
+                .andThen(GoToInches_ExitOnRoll(center_DriveToRamp_inches, 0.0))
                 // Split move into two to avoid doing it too fast
                 .andThen(GoToInches(center_DriverOverRamp_inches / 2, 0.0))
                 .andThen(GoToInches(center_DriverOverRamp_inches, 0.0))
                 .andThen(GoToInches_ExitOnRoll(center_DriveToRamp_inches, 0.0))
                 .andThen(new AutoBalanceCommand(m_drivetrainSubsystem)));
 
-        m_chooser.addOption("Left: Driveout",
-                GoToInches(side_DrivePastRamp, 0));
+        m_chooser.addOption("Left: Drive Out",
+                EjectCubeSequence
+                .andThen(GoToInches(side_DrivePastRamp, 0)));
 
-        m_chooser.addOption("Left: Driveout + Charge",
-                GoToInches(side_DrivePastRamp, 0)
+        m_chooser.addOption("Left: Drive Out + Charge",
+                EjectCubeSequence
+                .andThen(GoToInches(side_DrivePastRamp, 0))
                 .andThen(GoToInches(side_DrivePastRamp, left_StrafeToRamp))
                 .andThen(GoToInches_ExitOnRoll(center_DriveToRamp_inches, left_StrafeToRamp))
                 .andThen(new AutoBalanceCommand(m_drivetrainSubsystem)));
 
-        m_chooser.addOption("Right: Driveout",
-                GoToInches(side_DrivePastRamp, 0));
+        m_chooser.addOption("Right: Drive Out",
+                EjectCubeSequence
+                .andThen(GoToInches(side_DrivePastRamp, 0)));
 
-        m_chooser.addOption("Right: Driveout + Charge",
-                GoToInches(side_DrivePastRamp, 0)
+        m_chooser.addOption("Right: Drive Out + Charge",
+                EjectCubeSequence
+                .andThen(GoToInches(side_DrivePastRamp, 0))
                 .andThen(GoToInches(side_DrivePastRamp, right_StrafeToRamp))
                 .andThen(GoToInches_ExitOnRoll(center_DriveToRamp_inches, right_StrafeToRamp))
                 .andThen(new AutoBalanceCommand(m_drivetrainSubsystem)));

--- a/src/main/java/frc/robot/subsystems/CubeFlipperSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CubeFlipperSubsystem.java
@@ -1,0 +1,26 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import edu.wpi.first.wpilibj.Servo;
+import static frc.robot.Constants.*;
+
+public class CubeFlipperSubsystem extends SubsystemBase {
+
+    Servo flipperServo = new Servo(CUBE_FLIPPER_SERVO_CHANNEL);
+
+    public CubeFlipperSubsystem() {
+        park();
+    }
+
+    public void park() {
+        flipperServo.set(CUBE_FLIPPER_SERVO_PARK_POS);
+    }
+
+    public void eject() {
+        flipperServo.set(CUBE_FLIPPER_SERVO_EJECT_POS);
+    }
+}


### PR DESCRIPTION
This add a simple Subsystem for a servo-based cube flipper. This could be used as a contingency option in case we don't have more advanced cube handling avaialble. It may also be useful as a simple option to use only in autonomous, while more advanced handling is used during tele-op play.

Implemention:
- Add a CubeFlipperSubsystem
- Add a simple sequence to eject a cube
- Add the cube ejection sequence to all autonomous commands, assuming that "None" is the only time we would want to skip it.

This adds two seconds to each autonomous commands, which is unlikely to interfere with our other activities.